### PR TITLE
0.1.2-pre-alpha READY.FOR.RELEASE

### DIFF
--- a/n.READY.FOR.RELEASE
+++ b/n.READY.FOR.RELEASE
@@ -1,20 +1,19 @@
-0.1.1-pre-alpha READY.FOR.RELEASE
+0.1.2-pre-alpha READY.FOR.RELEASE
 
-last commit 56be789af1a57b12a83cc332ebfedfe0255639a2
+last commit 847029a5862342b7450b73068d0a1d6b4bda548b
 
-Date:   Mon Nov 21 01:05:22 UTc 2022
+Date:   Tue Nov 22 22:44:26 UTC 2022
 
-    for Arduino IDE iirc
+    add one forth source
 
-
-commit 56be789af1a57b12a83cc332ebfedfe0255639a2
+commit 847029a5862342b7450b73068d0a1d6b4bda548b
 Author: wa1tnr <wa1tnr@users.noreply.github.com>
-Date:   Mon Nov 21 01:05:22 2022 +0000
+Date:   Tue Nov 22 22:44:26 2022 +0000
 
-    for Arduino IDE iirc
+    add one forth source
 
-commit daeda20f8d09c67b0460909130ec6729e5c19a9c
+commit a5ef5f3b3af65711040a2d40923c6bcb733ac5f7
 Author: wa1tnr <wa1tnr@users.noreply.github.com>
-Date:   Mon Nov 21 00:59:47 2022 +0000
+Date:   Tue Nov 22 22:15:04 2022 +0000
 
 END.


### PR DESCRIPTION
  Has ESP32forth v7.0.7.4   Rev. 595ed9e8296c64661139
  Has ESP.reset() for the 'bye' word - no more
  backtrace on a bye

	modified:   n.READY.FOR.RELEASE

On branch develop